### PR TITLE
Humbundee OTP Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /rebar
+rebar.lock
 
 /_build/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /rebar
 
+/_build/
+
 /tmp/
 /releases
 

--- a/etc/reltool.config
+++ b/etc/reltool.config
@@ -17,7 +17,6 @@
  {sys,
   [{lib_dirs, ["lib", "deps"]},
    {incl_cond, exclude},
-   {excl_archive_filters, [".*"]},
 
    {app, kernel,       [{incl_cond, include}]},
    {app, stdlib,       [{incl_cond, include}]},
@@ -43,7 +42,6 @@
  {sys,
   [{lib_dirs, ["lib", "deps"]},
    {incl_cond, exclude},
-   {excl_archive_filters, [".*"]},
 
    {app, kernel,       [{incl_cond, include}]},
    {app, stdlib,       [{incl_cond, include}]},

--- a/lib/deploy/src/deploy.app.src
+++ b/lib/deploy/src/deploy.app.src
@@ -25,7 +25,7 @@
 {application, deploy,
  [{description, "Service configuration tool"},
   {vsn, "0.0.1"},
-  {modules, [=MODULES=]},
+  {modules, []},
   {registered, []},
   {applications, [kernel, stdlib]}
  ]}.

--- a/lib/humbundee/src/hbd_cfg.erl
+++ b/lib/humbundee/src/hbd_cfg.erl
@@ -83,7 +83,7 @@ add_user_config(Cfg) ->
     end.
 
 get_home() ->
-    case os:getenv(<<"HOME">>) of
+    case os:getenv("HOME") of
         false -> no_home();
         Home -> Home
     end.

--- a/lib/humbundee/src/humbundee.app.src
+++ b/lib/humbundee/src/humbundee.app.src
@@ -29,7 +29,6 @@
   {vsn, "0.0.1"},
   {modules,
    [
-    =MODULES=
    ]},
   {registered, [hbd_sup, hbd_get_sup]},
   {applications, [kernel, stdlib, sasl, lager]},


### PR DESCRIPTION
With this update: Humbundee runs on the latest OTP version, using rebar3, releases are built using reltool. Humbundee runs as a background node that can be attached to using to_erl